### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/test-pmvnorm.cpp
+++ b/src/test-pmvnorm.cpp
@@ -34,16 +34,11 @@ context("pmvnorm unit tests") {
     parallelrng::set_rng_seeds(1L);
     constexpr double Inf = std::numeric_limits<double>::infinity();
 
-    arma::vec lower, upper, mean;
-    arma::mat sigma;
-
-    lower << -Inf << 0.184 << -Inf << 1.595;
-    upper << 1.004 << Inf << Inf << 2.334;
-    mean << 0.576 << -0.305 << 1.512 << 0.39;
-
-    sigma << 4.869 << -0.099 << 0.961 << 1.726 << -0.099 << 5.01 << -2.789
-          << 0.132 << 0.961 << -2.789 << 6.67 << -4.177 << 1.726 << 0.132
-          << -4.177 << 7.966;
+    arma::vec lower({ -Inf, 0.184, -Inf, 1.595 }),
+      upper( { 1.004, Inf, Inf, 2.334 }),
+      mean( {  0.576,-0.305, 1.512, 0.39 });
+    arma::mat sigma( { 4.869, -0.099, 0.961, 1.726, -0.099, 5.01, -2.789,
+	0.132, 0.961, -2.789, 6.67, -4.177, 1.726, 0.132, -4.177, 7.966 } );
     sigma.reshape(4L, 4L);
 
     double const abs_eps = std::sqrt(std::numeric_limits<double>::epsilon());

--- a/src/test-restrict-cdf.cpp
+++ b/src/test-restrict-cdf.cpp
@@ -27,20 +27,15 @@ context("restrictcdf unit tests") {
     std::vector<unsigned> seeds = { 1L };
     parallelrng::set_rng_seeds(seeds);
 
-    arma::vec mean;
-    arma::mat sigma;
-
-    mean << -0.626 << 0.18 << -0.836 << 1.595;
-
-    sigma << 8.287 << -0.848 << -0.879 << -1.788 << -0.848 << 3.581
-          << 2.916 << -3.957 << -0.879 << 2.916 << 7.361 << -0.648
-          << -1.788 << -3.957 << -0.648 << 11.735;
+    arma::vec mean( { -0.626, 0.18, -0.836, 1.595 });
+    arma::mat sigma( { 8.287, -0.848, -0.879, -1.788, -0.848, 3.581,
+	2.916, -3.957, -0.879, 2.916, 7.361, -0.648 , -1.788, -3.957, -0.648, 11.735 });
     sigma.reshape(4L, 4L);
     restrictcdf::likelihood::alloc_mem(4L, 1L);
 
     double const abs_eps = std::pow(std::numeric_limits<double>::epsilon(),
                                    .33);
-    double constexpr E_prop(0.0181507102495727);
+    double constexpr const E_prop(0.0181507102495727);
     {
       restrictcdf::likelihood functor;
       auto res = restrictcdf::cdf<restrictcdf::likelihood>(
@@ -83,18 +78,15 @@ context("restrictcdf unit tests") {
      */
     std::vector<unsigned> seeds = { 1L };
     parallelrng::set_rng_seeds(seeds);
-    constexpr double Inf = std::numeric_limits<double>::infinity();
+    constexpr double const Inf = std::numeric_limits<double>::infinity();
 
-    arma::vec lower, upper, mean;
-    arma::mat sigma;
-
-    lower << -Inf   << -1   << 1      << -Inf;
-    upper << 1      << Inf  << 3      << 2;
-    mean  << -0.626 << 0.18 << -0.836 << 1.595;
-
-    sigma << 8.287 << -0.848 << -0.879 << -1.788 << -0.848 << 3.581
-          << 2.916 << -3.957 << -0.879 << 2.916 << 7.361 << -0.648
-          << -1.788 << -3.957 << -0.648 << 11.735;
+    arma::vec
+      lower( { -Inf  , -1  , 1     , -Inf }),
+      upper( { 1     , Inf , 3     , 2 }),
+      mean(  { -0.626, 0.18, -0.836, 1.595 }); 
+    arma::mat sigma({ 8.287, -0.848, -0.879, -1.788, -0.848, 3.581,
+	2.916, -3.957, -0.879, 2.916, 7.361, -0.648,
+	-1.788, -3.957, -0.648, 11.735 });
     sigma.reshape(4L, 4L);
     restrictcdf::likelihood::alloc_mem(4L, 1L);
 
@@ -136,11 +128,11 @@ context("restrictcdf unit tests") {
  f(mu, va)
  }, l = lbs, u = ubs))
  */
-    arma::vec lbs, ubs, expect;
-    constexpr double Inf = std::numeric_limits<double>::infinity();
-    lbs << -1  << -Inf << -.5;
-    ubs << Inf << 1    << 2;
-    expect << 0.953233743655453 << 0.711924938984711 << 0.821457505013967;
+    constexpr double const Inf = std::numeric_limits<double>::infinity();
+    arma::vec
+      lbs( { -1, -Inf, -.5 }),
+      ubs( { Inf, 1   , 2 }),
+      expect( { 0.953233743655453, 0.711924938984711, 0.821457505013967 });
     double const mu(.5);
     double const va(.8);
 
@@ -197,14 +189,14 @@ context("restrictcdf unit tests") {
    c(v1, v2)
    }, l = lbs, u = ubs))
    */
-    arma::vec lbs, ubs;
-    arma::mat expect;
-    constexpr double Inf = std::numeric_limits<double>::infinity();
-    lbs << -1  << -Inf << -.5;
-    ubs << Inf << 1    << 2;
-    expect << 0.953233743655453 << 0.109304604505804  << -0.102473066720416
-           << 0.711924938984711 << -0.381510556527341 << -0.119222048911591
-           << 0.821457505013967 << 0.129438601257233  << -0.251687570316064;
+    constexpr double const Inf = std::numeric_limits<double>::infinity();
+    arma::vec
+      lbs( { -1 , -Inf, -.5 }),
+      ubs( { Inf, 1   , 2 });
+    arma::mat expect( { 0.953233743655453, 0.109304604505804 , -0.102473066720416,
+	0.711924938984711, -0.381510556527341, -0.119222048911591,
+	0.821457505013967, 0.129438601257233 , -0.251687570316064 } );
+
     expect.reshape(3, 3);
     double const mu(.5);
     double const va(.8);
@@ -286,23 +278,17 @@ context("restrictcdf unit tests") {
     std::vector<unsigned> seeds = { 1L };
     parallelrng::set_rng_seeds(seeds);
 
-    arma::vec mean;
-    arma::mat sigma;
-
-    mean << -0.897 << 0.185 << 1.588 << -1.13;
-
-    sigma << 6.703 << -0.621 << -0.359 << -1.017 << -0.621 << 3.85 << 0.847
-          << -1.931 << -0.359 << 0.847 << 13.438 << 6.106 << -1.017
-          << -1.931 << 6.106 << 11.67;
+    arma::vec mean( { -0.897, 0.185, 1.588, -1.13 });
+    arma::mat sigma( {  6.703, -0.621, -0.359, -1.017, -0.621, 3.85, 0.847,
+	-1.931, -0.359, 0.847, 13.438, 6.106, -1.017, -1.931, 6.106, 11.67 });
     sigma.reshape(4L, 4L);
     restrictcdf::deriv::alloc_mem(4L, 1L);
 
-    arma::vec expect;
-    expect << 0.0724695784076199 << -0.0198615541220946 << -0.0348869861554662
-           << -0.0165673832643242 << -0.01129675889845 << -0.00060013043408606
-           << 0.00434208509359746 << 0.00150139459997432 << 0.00229746814495135
-           << 0.00453344700742309 << -0.000140031793841558 << 0.00134120630703679
-           << 0.00191440588268495 << 0.00196875385020239 << -0.00114337234043834;
+    arma::vec expect( {  0.0724695784076199, -0.0198615541220946, -0.0348869861554662,
+	  -0.0165673832643242, -0.01129675889845, -0.00060013043408606,
+	  0.00434208509359746, 0.00150139459997432, 0.00229746814495135,
+	  0.00453344700742309, -0.000140031793841558, 0.00134120630703679,
+	  0.00191440588268495, 0.00196875385020239, -0.00114337234043834 });
 
     double const abs_eps = std::pow(
       std::numeric_limits<double>::epsilon(), .25);
@@ -367,26 +353,22 @@ context("restrictcdf unit tests") {
     std::vector<unsigned> seeds = { 1L };
     parallelrng::set_rng_seeds(seeds);
 
-    arma::vec lower, upper, mean;
-    arma::mat sigma;
-    constexpr double Inf = std::numeric_limits<double>::infinity();
+    constexpr double const Inf = std::numeric_limits<double>::infinity();
+    arma::vec
+      lower( { -Inf , -1   , 1    , -Inf } ),
+      upper( { 1    , Inf  , 3    , 2 } ),
+      mean( { -0.897, 0.185, 1.588, -1.13 } );
+    arma::mat sigma( { 6.703, -0.621, -0.359, -1.017, -0.621, 3.85, 0.847,
+	-1.931, -0.359, 0.847, 13.438, 6.106, -1.017, -1.931, 6.106, 11.67 });
 
-    lower << -Inf  << -1    << 1     << -Inf;
-    upper << 1     << Inf   << 3     << 2;
-    mean << -0.897 << 0.185 << 1.588 << -1.13;
-
-    sigma << 6.703 << -0.621 << -0.359 << -1.017 << -0.621 << 3.85 << 0.847
-          << -1.931 << -0.359 << 0.847 << 13.438 << 6.106 << -1.017
-          << -1.931 << 6.106 << 11.67;
     sigma.reshape(4L, 4L);
     restrictcdf::deriv::alloc_mem(4L, 1L);
 
-    arma::vec expect;
-    expect << 0.10798294314481     << -0.016084833560177   << 0.0207517208958157
-           << 0.00542773417060216  << -0.00878426310906256 << -0.00239199279704842
-           << -0.00184810009109447 << -0.00451083625704058 << -0.000415749485688216
-           << 0.00120569609620797  << -0.00426153807790556 << 0.000511171228139317
-           << -0.00150307105427825 << 0.000764221234825768 << -0.00178202876555804;
+    arma::vec expect( { 0.10798294314481    , -0.016084833560177  , 0.0207517208958157,
+	  0.00542773417060216 , -0.00878426310906256, -0.00239199279704842,
+	  -0.00184810009109447, -0.00451083625704058, -0.000415749485688216,
+	  0.00120569609620797 , -0.00426153807790556, 0.000511171228139317,
+	  -0.00150307105427825, 0.000764221234825768, -0.00178202876555804 });
 
     double const abs_eps = std::pow(
       std::numeric_limits<double>::epsilon(), .25);


### PR DESCRIPTION
These changes update RcppArmadillo from the now deprecated `<<` initialization to brace initialization allowed since C++11 and long been the minimal standard with R too.  It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391

(There is another `#pragma deprecated` warning about error printing you probably need to take care of too. Let me know if you want to look at that too.)